### PR TITLE
Update CHANGELOG Documentation for Versions 1.4.5, 1.4.4, and 1.4.3

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,25 @@
+```markdown
+# CHANGELOG
+
+## [1.4.5] - YYYY-MM-DD
+### Added
+- Added a new utility function `validateAddress` to ensure Ethereum addresses are valid, including checks for hex character validity.
+- Introduced a `timeoutMs` parameter to the `isAGWAccount` function to handle potential timeouts during contract read operations.
+
+### Changed
+- Updated the `getAgwTypedSignature` function to include a `domainVersion` parameter, allowing for custom EIP-712 domain versioning. The default version is now "2.0.0".
+- Added validation for the `messageHash` format in `getAgwTypedSignature` to ensure it is a 32-byte hex string.
+
+### Fixed
+- Improved error handling in `isAGWAccount` by implementing a timeout mechanism.
+
+## [1.4.4] - YYYY-MM-DD
+### Changed
+- Updated package version to 1.4.4 in `package.json`.
+
+## [1.4.3] - YYYY-MM-DD
+### Changed
+- Updated package version to 1.4.3 in `package.json`.
+
+(Note: Replace `YYYY-MM-DD` with the actual release dates.)
+```


### PR DESCRIPTION
This pull request updates the `CHANGELOG.md` documentation to include detailed information about the recent changes and enhancements in versions 1.4.5, 1.4.4, and 1.4.3. Below is a summary of the updates:

- **Version 1.4.5:**
  - Introduced new features:
    - Added a `validateAddress` utility function.
    - Added a `timeoutMs` parameter to the `isAGWAccount` function for improved error handling.
  - Enhanced the `getAgwTypedSignature` function to support custom EIP-712 domain versioning and validate the `messageHash` format.
  - Improved error handling in the `isAGWAccount` function with a timeout mechanism.

- **Versions 1.4.4 and 1.4.3:**
  - Updated the package version in `package.json`.

Please note that the release dates for these versions are currently placeholders and need to be updated with the actual release dates.

This documentation update ensures that users and developers have access to the latest information regarding the features and improvements in these versions.