### PR TITLE
Update signTransaction documentation to reflect handling of undefined transaction data

### DIFF
--- a/agw-client/actions/signTransaction.mdx
+++ b/agw-client/actions/signTransaction.mdx
@@ -1,0 +1,1 @@
+Please update the documentation to reflect the changes made to the signTransaction function in the SDK. The function now includes a check for undefined transaction data and sets it to '0x' to avoid issues with contracts that do not have a fallback function.


### PR DESCRIPTION
The signTransaction function now explicitly handles cases where transactionWithPaymaster.data is undefined, setting it to '0x' to prevent issues with contracts lacking a fallback function. This change should be documented in the signTransaction.mdx file.